### PR TITLE
Close files after opening

### DIFF
--- a/language_tags/Subtag.py
+++ b/language_tags/Subtag.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import six
 
-from io import open
+from language_tags import data
 
-parent_dir = os.path.dirname(__file__)
-data_dir = 'data/json/'
-index = json.load(open(os.path.join(parent_dir, data_dir, "index.json"), encoding='utf-8'))
-registry = json.load(open(os.path.join(parent_dir, data_dir, "registry.json"), encoding='utf-8'))
+
+index = data.get('index')
+registry = data.get('registry')
 
 
 class Subtag:

--- a/language_tags/Tag.py
+++ b/language_tags/Tag.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 import six
-import os
 
-from io import open
 
 from language_tags.Subtag import Subtag
+from language_tags import data
 
-parent_dir = os.path.dirname(__file__)
-data_dir = 'data/json/'
-index = json.load(open(os.path.join(parent_dir, data_dir, "index.json"), encoding='utf-8'))
-registry = json.load(open(os.path.join(parent_dir, data_dir, "registry.json"), encoding='utf-8'))
+
+index = data.get('index')
+registry = data.get('registry')
 
 
 class Tag:

--- a/language_tags/data/__init__.py
+++ b/language_tags/data/__init__.py
@@ -1,0 +1,18 @@
+import os
+import json
+from io import open
+
+__all__ = ['get']
+
+parent_dir = os.path.dirname(__file__)
+data_dir = 'json/'
+
+cache = {}
+
+
+def get(name):
+    if name not in cache:
+        with open(os.path.join(parent_dir, data_dir, "%s.json" % name), encoding='utf-8') as f:
+            cache[name] = json.load(f)
+
+    return cache[name]

--- a/language_tags/tags.py
+++ b/language_tags/tags.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
-import os
-import json
 import six
-
-from io import open
 
 from language_tags.Subtag import Subtag
 from language_tags.Tag import Tag
+from language_tags import data
 
 
-parent_dir = os.path.dirname(__file__)
-data_dir = 'data/json/'
-index = json.load(open(os.path.join(parent_dir, data_dir + "index.json"), encoding='utf-8'))
-registry = json.load(open(os.path.join(parent_dir, data_dir + "registry.json"), encoding='utf-8'))
+index = data.get('index')
+registry = data.get('registry')
+
 
 class tags():
 
@@ -145,7 +141,7 @@ class tags():
         results = []
 
         macrolanguage = macrolanguage.lower()
-        macrolanguage_data = json.load(open(os.path.join(parent_dir, data_dir, "macrolanguage.json")))
+        macrolanguage_data = data.get('macrolanguage')
         if macrolanguage not in macrolanguage_data:
             raise Exception('\'' + macrolanguage + '\' is not a macrolanguage.')
         for registry_item in registry:
@@ -199,5 +195,5 @@ class tags():
 
         :return: date as string (for example: '2014-03-27').
         """
-        meta = json.load(open(os.path.join(parent_dir, data_dir, "meta.json")))
+        meta = data.get('meta')
         return meta['File-Date']

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ HISTORY = open(os.path.join(here, 'HISTORY.rst')).read()
 
 packages = [
     'language_tags',
+    'language_tags.data',
 ]
 
 requires = ['six']


### PR DESCRIPTION
Avoids warnings like "ResourceWarning: unclosed file ..."

In addition the files are now cached on load, avoiding triplicated
reads of index.json and registry.json on startup.