### PR TITLE
Avoid modifying tag when getting description

### DIFF
--- a/language_tags/tags.py
+++ b/language_tags/tags.py
@@ -126,7 +126,8 @@ class tags():
         :return: list of string descriptions. The return list can be empty.
         """
         tag_object = Tag(tag)
-        results = tag_object.descriptions
+        results = []
+        results.extend(tag_object.descriptions)
         subtags = tag_object.subtags
         for subtag in subtags:
             results += subtag.description

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -108,6 +108,7 @@ class TestSubtag(unittest.TestCase):
         self.assertIn('Belgium', description)
         description = tags.description('az-Arab')
         self.assertIn('Azerbaijani in Arabic script', description)
+        self.assertEqual(len(description), len(tags.description('az-Arab')))
         description = tags.description('123')
         self.assertEqual(0, len(description))
         description = tags.description('vls')


### PR DESCRIPTION
tags.description was inadvertently modifying the tag data,
causing subsequent uses of that tag to give incorrect results.

Example:

```
from language_tags import tags

a = len(tags.description('es-419'))
b = len(tags.description('es-419'))

# assert 4 == 7
assert a == b
```