### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include *.txt *.ini *.cfg *.rst *.md *.json
+include *.txt *.ini *.cfg *.rst *.md *.json LICENSE
 recursive-include language_tags *.txt *.json


### PR DESCRIPTION
Thanks for maintaining this!

While not strictly _required_ by MIT, it's nice for [downstreams](https://github.com/conda-forge/staged-recipes/pull/13362) if the canonical LICENSE is packaged... this just adds it to the sdist!

